### PR TITLE
Multiline string indent 3

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRule.kt
@@ -747,6 +747,20 @@ class IndentationRule : Rule("indent"), Rule.Modifier.RestrictToRootLast {
     ) {
         val psi = node.psi as KtStringTemplateExpression
         if (psi.isMultiLine() && psi.isFollowedByTrimIndent()) {
+            if (node.containsMixedIndentationCharacters()) {
+                // It can not be determined with certainty how mixed indentation characters should be interpreted.
+                // The trimIndent function handles tabs and spaces equally (one tabs equals one space) while the user
+                // might expect that the tab size in the indentation is more than one space.
+                emit(
+                    node.startOffset,
+                    "Indentation of multiline string should not contain both tab(s) and space(s)",
+                    false
+                )
+                return
+            }
+
+            val children = node.children()
+
             // Get the max prefix length that all line in the multiline string have in common. All whitespace character
             // are counted as one single position. Note that the way of counting should be in sync with the way this is
             // done by the trimIndent function.
@@ -1025,6 +1039,27 @@ class IndentationRule : Rule("indent"), Rule.Modifier.RestrictToRootLast {
     //       T2 : SubType...
     private fun ASTNode.isPartOfTypeConstraint() =
         isPartOf(TYPE_CONSTRAINT_LIST) || nextLeaf()?.elementType == WHERE_KEYWORD
+
+    private fun ASTNode.containsMixedIndentationCharacters(): Boolean {
+        assert((this.psi as KtStringTemplateExpression).isMultiLine())
+        val nonBlankLines = this
+            .text
+            .split("\n")
+            .filterNot { it.startsWith("\"\"\"") }
+            .filterNot { it.endsWith("\"\"\"") }
+            .filterNot { it.isBlank() }
+        val prefixLength = nonBlankLines
+            .map { it.indentLength() }
+            .min() ?: 0
+        val distinctIndentCharacters = nonBlankLines
+            .joinToString(separator = "") {
+                it.splitIndentAt(prefixLength).first
+            }
+            .toCharArray()
+            .distinct()
+            .count()
+        return distinctIndentCharacters > 1
+    }
 }
 
 private fun ASTNode.isIndentBeforeClosingQuote() =

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRuleTest.kt
@@ -1,7 +1,6 @@
 package com.pinterest.ktlint.ruleset.standard
 
 import com.pinterest.ktlint.core.LintError
-import com.pinterest.ktlint.test.assertThatFileFormat
 import com.pinterest.ktlint.test.diffFileFormat
 import com.pinterest.ktlint.test.diffFileLint
 import com.pinterest.ktlint.test.format

--- a/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/pinterest/ktlint/ruleset/standard/IndentationRuleTest.kt
@@ -1,12 +1,12 @@
 package com.pinterest.ktlint.ruleset.standard
 
 import com.pinterest.ktlint.core.LintError
+import com.pinterest.ktlint.test.assertThatFileFormat
 import com.pinterest.ktlint.test.diffFileFormat
 import com.pinterest.ktlint.test.diffFileLint
 import com.pinterest.ktlint.test.format
 import com.pinterest.ktlint.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Ignore
 import org.junit.Test
 
 internal class IndentationRuleTest {
@@ -821,7 +821,6 @@ internal class IndentationRuleTest {
         assertThat(IndentationRule().format(code)).isEqualTo(code)
     }
 
-    @Ignore
     @Test
     fun `issue 575 - lint multiline string with mixed indentation characters, can not be autocorrected`() {
         val code =

--- a/ktlint-ruleset-standard/src/test/resources/spec/indent/format-raw-string-trim-indent-expected.kt.spec
+++ b/ktlint-ruleset-standard/src/test/resources/spec/indent/format-raw-string-trim-indent-expected.kt.spec
@@ -78,18 +78,16 @@ fun f() {
         end_of_line = lf
         """.trimIndent().toByteArray()
     )
-    SpacingAroundKeywordRule().format(
-        // string below is indented with tabs and spaces should and should therefore not be autocorrected as this can
-        // not been done reliable. This will be fixed in a separate PR.
+    SpacingAroundKeywordRule().format( // string below is indented with tabs and spaces and will not be changed
         """
-             var x: String
-        get () {
-         return ""
-        }
-        private set (value) {
-         x = value
-        }
-        """.trimIndent()
+            var x: String
+			    get () {
+				    return ""
+			    }
+			    private set (value) {
+				    x = value
+			    }
+            """.trimIndent()
     )
 }
 

--- a/ktlint-ruleset-standard/src/test/resources/spec/indent/format-raw-string-trim-indent.kt.spec
+++ b/ktlint-ruleset-standard/src/test/resources/spec/indent/format-raw-string-trim-indent.kt.spec
@@ -62,9 +62,7 @@ _""".trimIndent())
         [*]
         end_of_line = lf
     """.trimIndent().toByteArray())
-            SpacingAroundKeywordRule().format(
-                // string below is indented with tabs and spaces should and should therefore not be autocorrected as this can
-                // not been done reliable. This will be fixed in a separate PR.
+            SpacingAroundKeywordRule().format( // string below is indented with tabs and spaces and will not be changed
                 """
             var x: String
 			    get () {


### PR DESCRIPTION
Add check on mixed indentation characters in a multilinestring

Whenever the indentation of a multiline string contains both tabs and spaces then the indentation can not be autocorrected with certainty. So only report as violation.